### PR TITLE
Revamp wizard spells and skills UX

### DIFF
--- a/src/components/views/SpellsView.tsx
+++ b/src/components/views/SpellsView.tsx
@@ -1,22 +1,31 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { spells } from '../../data/spells';
 import type { Spell } from '../../types';
-import { X, Scroll, Sparkles, Clock, Target, Hourglass } from 'lucide-react';
+import { X, Scroll, Sparkles, Clock, Target, Hourglass, Zap, ShieldCheck, Wand2, Activity } from 'lucide-react';
+import { getRequiredLevelForSpell } from '../../utils/spellRules';
 
-export function SpellsView() {
+interface SpellsViewProps {
+    level: number;
+    concentration: string | null;
+    onSetConcentration: (spell: string) => void;
+}
+
+export function SpellsView({ level, concentration, onSetConcentration }: SpellsViewProps) {
     const [selectedSpell, setSelectedSpell] = useState<Spell | null>(null);
 
-    const cantrips = spells.filter(s => s.lvl === 0);
-    const level1 = spells.filter(s => s.lvl === 1);
-    const level2 = spells.filter(s => s.lvl === 2);
-    const level3 = spells.filter(s => s.lvl === 3);
+    const { cantrips, level1, level2, level3 } = useMemo(() => ({
+        cantrips: spells.filter(s => s.lvl === 0),
+        level1: spells.filter(s => s.lvl === 1),
+        level2: spells.filter(s => s.lvl === 2),
+        level3: spells.filter(s => s.lvl === 3)
+    }), []);
 
     return (
         <div className="pb-20">
-            <SpellList title="Cantrips" list={cantrips} onSelect={setSelectedSpell} />
-            <SpellList title="Level 1" list={level1} onSelect={setSelectedSpell} />
-            <SpellList title="Level 2" list={level2} onSelect={setSelectedSpell} />
-            <SpellList title="Level 3" list={level3} onSelect={setSelectedSpell} />
+            <SpellList title="Cantrips" list={cantrips} level={level} onSelect={setSelectedSpell} />
+            <SpellList title="Level 1" list={level1} level={level} onSelect={setSelectedSpell} />
+            <SpellList title="Level 2" list={level2} level={level} onSelect={setSelectedSpell} />
+            <SpellList title="Level 3" list={level3} level={level} onSelect={setSelectedSpell} />
 
             {/* Spell Detail Modal */}
             {selectedSpell && (
@@ -41,15 +50,32 @@ export function SpellsView() {
                                         <span className="text-white/30">•</span>
                                         <span>{selectedSpell.school}</span>
                                     </div>
+                                    <div className="text-[10px] text-muted mt-2">
+                                        Required level {getRequiredLevelForSpell(selectedSpell.lvl)} • You are level {level}
+                                    </div>
                                 </div>
                             </div>
-                            <button
-                                onClick={() => setSelectedSpell(null)}
-                                className="flex items-center justify-center w-10 h-10 rounded-full bg-white/5 border border-white/20 text-white/60 hover:text-white hover:bg-white/10 hover:border-white/40 transition-all shrink-0"
-                                aria-label="Close"
-                            >
-                                <X size={20} />
-                            </button>
+                            <div className="flex items-center gap-2">
+                                {selectedSpell.concentration && (
+                                    <button
+                                        onClick={() => onSetConcentration(selectedSpell.name)}
+                                        className={`text-[10px] px-3 py-1 rounded-full border transition-colors ${
+                                            concentration === selectedSpell.name
+                                                ? 'bg-white/20 text-white border-white/40'
+                                                : 'bg-white/5 text-muted border-white/20 hover:text-white hover:border-white/40'
+                                        }`}
+                                    >
+                                        {concentration === selectedSpell.name ? 'Concentrating' : 'Set Concentration'}
+                                    </button>
+                                )}
+                                <button
+                                    onClick={() => setSelectedSpell(null)}
+                                    className="flex items-center justify-center w-10 h-10 rounded-full bg-white/5 border border-white/20 text-white/60 hover:text-white hover:bg-white/10 hover:border-white/40 transition-all shrink-0"
+                                    aria-label="Close"
+                                >
+                                    <X size={20} />
+                                </button>
+                            </div>
                         </div>
 
                         {/* Scrollable Content */}
@@ -86,6 +112,61 @@ export function SpellsView() {
                                 </div>
                             </div>
 
+                            <div className="grid grid-cols-2 gap-3 mb-6">
+                                <div className="bg-card-elevated/80 p-3 rounded-lg border border-white/10">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <Wand2 size={12} className="text-white" />
+                                        <span className="text-[10px] text-muted uppercase tracking-wider">What It Does</span>
+                                    </div>
+                                    <div className="text-sm text-parchment-light">{selectedSpell.effect}</div>
+                                </div>
+                                <div className="bg-card-elevated/80 p-3 rounded-lg border border-white/10">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <ShieldCheck size={12} className="text-white" />
+                                        <span className="text-[10px] text-muted uppercase tracking-wider">Rolls</span>
+                                    </div>
+                                    <div className="text-sm text-parchment-light">{selectedSpell.rolls}</div>
+                                </div>
+                                <div className="bg-card-elevated/80 p-3 rounded-lg border border-white/10">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <Zap size={12} className="text-white" />
+                                        <span className="text-[10px] text-muted uppercase tracking-wider">Damage</span>
+                                    </div>
+                                    <div className="text-sm text-parchment-light">{selectedSpell.damage}</div>
+                                </div>
+                                <div className="bg-card-elevated/80 p-3 rounded-lg border border-white/10">
+                                    <div className="flex items-center gap-2 mb-1">
+                                        <Activity size={12} className="text-white" />
+                                        <span className="text-[10px] text-muted uppercase tracking-wider">Damage Type</span>
+                                    </div>
+                                    <div className="text-sm text-parchment-light">{selectedSpell.damageType}</div>
+                                </div>
+                            </div>
+
+                            <div className="bg-card-elevated/60 p-4 rounded-lg border border-white/10 mb-6">
+                                <div className="text-[10px] text-muted uppercase tracking-wider mb-3">Decision Tree by Level</div>
+                                <div className="space-y-2">
+                                    {selectedSpell.decisionTree.map((node) => {
+                                        const isActive = level >= node.level;
+                                        return (
+                                            <div
+                                                key={`${selectedSpell.name}-${node.level}`}
+                                                className={`flex items-start gap-3 rounded-lg border px-3 py-2 ${
+                                                    isActive
+                                                        ? 'border-white/30 bg-white/10 text-parchment-light'
+                                                        : 'border-white/10 bg-white/5 text-muted'
+                                                }`}
+                                            >
+                                                <div className={`text-[10px] uppercase tracking-wider ${isActive ? 'text-white' : 'text-muted/60'}`}>
+                                                    Level {node.level}
+                                                </div>
+                                                <div className="text-xs">{node.summary}</div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+
                             {/* Description */}
                             <div className="space-y-4 text-parchment text-sm leading-relaxed border-t border-white/10 pt-4">
                                 <p>{selectedSpell.desc}</p>
@@ -110,7 +191,17 @@ export function SpellsView() {
     );
 }
 
-const SpellList = ({ title, list, onSelect }: { title: string, list: Spell[], onSelect: (spell: Spell) => void }) => (
+const SpellList = ({
+    title,
+    list,
+    level,
+    onSelect
+}: {
+    title: string;
+    list: Spell[];
+    level: number;
+    onSelect: (spell: Spell) => void;
+}) => (
     <div className="mb-6">
         <div className="flex items-center gap-4 mb-3">
             <h3 className="font-display text-lg text-parchment-light tracking-wider">{title}</h3>
@@ -118,11 +209,17 @@ const SpellList = ({ title, list, onSelect }: { title: string, list: Spell[], on
             <span className="text-xs text-muted">{list.length} spells</span>
         </div>
         <div className="space-y-2">
-            {list.map((spell) => (
+            {list.map((spell) => {
+                const requiredLevel = getRequiredLevelForSpell(spell.lvl);
+                const isAvailable = level >= requiredLevel;
+                return (
                 <button
                     key={spell.name}
                     onClick={() => onSelect(spell)}
-                    className="w-full text-left card-parchment p-3 hover:border-white/30 transition-all group"
+                    className={`w-full text-left card-parchment p-3 transition-all group ${
+                        isAvailable ? 'hover:border-white/30' : 'opacity-60 cursor-not-allowed'
+                    }`}
+                    disabled={!isAvailable}
                 >
                     <div className="flex justify-between items-center relative z-10 min-w-0">
                         <div className="flex items-center gap-3 min-w-0 flex-1">
@@ -134,16 +231,27 @@ const SpellList = ({ title, list, onSelect }: { title: string, list: Spell[], on
                             </span>
                         </div>
                         <div className="flex items-center gap-2">
+                            {spell.concentration && (
+                                <span className="text-[10px] text-white/70 border border-white/20 px-2 py-0.5 rounded-full bg-white/5">
+                                    Conc.
+                                </span>
+                            )}
                             {spell.incantation && (
                                 <span className="text-[10px] text-white/70 border border-white/20 px-2 py-0.5 rounded-full bg-white/5">
                                     Verbal
+                                </span>
+                            )}
+                            {!isAvailable && (
+                                <span className="text-[10px] text-white/50 border border-white/10 px-2 py-0.5 rounded-full bg-white/5">
+                                    L{requiredLevel}+
                                 </span>
                             )}
                             <Sparkles size={14} className="text-muted group-hover:text-white transition-colors opacity-0 group-hover:opacity-100" />
                         </div>
                     </div>
                 </button>
-            ))}
+                );
+            })}
         </div>
     </div>
 );

--- a/src/components/widgets/ConcentrationWidget.tsx
+++ b/src/components/widgets/ConcentrationWidget.tsx
@@ -2,6 +2,7 @@ import { Eye, X } from 'lucide-react';
 
 interface ConcentrationWidgetProps {
     spell: string | null;
+    suggestions?: string[];
     onClear: () => void;
     onSet: (spell: string) => void;
 }
@@ -12,7 +13,7 @@ const CONCENTRATION_SPELLS = [
     'Invisibility', 'Hold Person', 'Animate Dead', 'Spirit Guardians'
 ];
 
-export function ConcentrationWidget({ spell, onClear, onSet }: ConcentrationWidgetProps) {
+export function ConcentrationWidget({ spell, suggestions = CONCENTRATION_SPELLS, onClear, onSet }: ConcentrationWidgetProps) {
     return (
         <div className="card-parchment p-4 mb-4">
             <div className="flex items-center justify-between mb-3">
@@ -44,7 +45,7 @@ export function ConcentrationWidget({ spell, onClear, onSet }: ConcentrationWidg
                 <div className="space-y-2">
                     <p className="text-xs text-muted">Not concentrating on any spell</p>
                     <div className="flex flex-wrap gap-1">
-                        {CONCENTRATION_SPELLS.slice(0, 4).map(s => (
+                        {suggestions.slice(0, 4).map(s => (
                             <button
                                 key={s}
                                 onClick={() => onSet(s)}

--- a/src/data/initialState.ts
+++ b/src/data/initialState.ts
@@ -59,5 +59,4 @@ export const initialCharacterData: CharacterData = {
     concentration: null,
     attunement: [],
     inventory: ["Component Pouch", "Arcane Focus", "Scholar's Pack"],
-    transformed: null
 };

--- a/src/data/spells.ts
+++ b/src/data/spells.ts
@@ -9,8 +9,16 @@ export const spells: Spell[] = [
         range: "60 ft",
         duration: "Instantaneous",
         components: "V, S",
-        attack: "Save: WIS DC 15",
-        damage: "2d8 (2d12 if damaged) Necrotic",
+        effect: "Ring a necrotic bell that punishes wounded targets.",
+        rolls: "WIS save vs DC 15",
+        damage: "2d8 (2d12 if damaged)",
+        damageType: "Necrotic",
+        decisionTree: [
+            { level: 1, summary: "Base damage: 1d8 (1d12 if damaged)." },
+            { level: 5, summary: "Damage scales to 2 dice (current tier)." },
+            { level: 11, summary: "Damage scales to 3 dice." },
+            { level: 17, summary: "Damage scales to 4 dice." }
+        ],
         desc: "Point at one creature you can see within range. The target must succeed on a Wisdom saving throw or take 2d8 necrotic damage. If the target is missing any of its hit points, it instead takes 2d12 necrotic damage. At Level 5, this cantrip deals 2 dice of damage (upgraded from 1 die).",
         incantation: "Mortis Tactus",
         pronunciation: "MOR-tis TAK-toos"
@@ -23,8 +31,16 @@ export const spells: Spell[] = [
         range: "30 ft",
         duration: "1 minute",
         components: "V, S",
-        attack: "Utility",
-        damage: "Spectral Hand",
+        effect: "Create a spectral hand to manipulate objects at range.",
+        rolls: "None",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base hand functions for light object manipulation." },
+            { level: 5, summary: "Use the hand in combat for quick object interactions." },
+            { level: 11, summary: "Handle delicate tasks at range with steady control." },
+            { level: 17, summary: "Keep the hand active while repositioning in combat." }
+        ],
         desc: "A spectral floating hand appears at a point you choose within range. The hand lasts for the duration or until you dismiss it as an action. The hand can manipulate an object, open an unlocked door or container, stow or retrieve an item from an open container, or pour the contents out of a vial.",
         incantation: "Manus Invisibilis",
         pronunciation: "MAH-noos in-vih-SEE-bih-lis"
@@ -37,8 +53,16 @@ export const spells: Spell[] = [
         range: "120 ft",
         duration: "1 round",
         components: "V, S, M",
-        attack: "Utility",
-        damage: "Whispered Msg",
+        effect: "Whisper a private message to a creature and receive a reply.",
+        rolls: "None",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base effect for short tactical whispers." },
+            { level: 5, summary: "Use every round to coordinate positioning." },
+            { level: 11, summary: "Maintain silent command loops across the battlefield." },
+            { level: 17, summary: "Keep whisper chains active during complex maneuvers." }
+        ],
         desc: "You point your finger toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear.",
         incantation: "Nuntius Susurrus",
         pronunciation: "NOON-tee-oos soo-SOO-roos"
@@ -51,8 +75,16 @@ export const spells: Spell[] = [
         range: "10 ft",
         duration: "Up to 1 hour",
         components: "V, S",
-        attack: "Utility",
-        damage: "Minor Effects",
+        effect: "Create minor magical effects for utility and flair.",
+        rolls: "None",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base effects: sensory, clean/soil, light/snuff." },
+            { level: 5, summary: "Layer multiple minor effects for distraction." },
+            { level: 11, summary: "Sustain long-form utility effects in downtime." },
+            { level: 17, summary: "Maintain multiple cantrip effects simultaneously." }
+        ],
         desc: "You create one of the following magical effects within range: a harmless sensory effect, light/snuff a candle, clean/soil an object, chill/warm material, make a color/mark/symbol appear, or create a trinket/illusion.",
         incantation: "Praestigia Minima",
         pronunciation: "pray-STIH-jee-ah MIN-ih-mah"
@@ -66,8 +98,16 @@ export const spells: Spell[] = [
         range: "60 ft",
         duration: "1 min (Conc.)",
         components: "V, S, M",
-        attack: "Save: WIS DC 14",
+        effect: "Force creatures into magical slumber.",
+        rolls: "WIS save vs DC 14",
         damage: "Unconscious",
+        damageType: "Condition",
+        decisionTree: [
+            { level: 1, summary: "Base effect: 5-foot-radius sphere of sleep." },
+            { level: 3, summary: "Upcast to affect tougher targets or more creatures." },
+            { level: 5, summary: "Upcast again for battlefield-wide control." }
+        ],
+        concentration: true,
         desc: "Creatures in a 5-foot-radius sphere must succeed on a Wisdom saving throw or be incapacitated and unconscious for the duration.",
         incantation: "Somnus",
         pronunciation: "SOM-noos"
@@ -80,8 +120,16 @@ export const spells: Spell[] = [
         range: "Self",
         duration: "10 min (Conc.)",
         components: "V, S",
-        attack: "Utility",
-        damage: "Sense Magic",
+        effect: "Sense magical auras in a 30-foot radius.",
+        rolls: "None",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base detection of magic within 30 feet." },
+            { level: 5, summary: "Maintain concentration while moving between rooms." },
+            { level: 9, summary: "Use while inspecting multiple targets quickly." }
+        ],
+        concentration: true,
         desc: "For the duration, you sense the presence of magic within 30 feet of you. If you sense magic in this way, you can use your action to see a faint aura around any visible creature or object in the area that bears magic, and you learn its school of magic, if any.",
         incantation: "Revelio Magica",
         pronunciation: "reh-VEH-lee-oh MAH-jee-kah"
@@ -94,8 +142,16 @@ export const spells: Spell[] = [
         range: "60 ft",
         duration: "1 min (Conc.)",
         components: "V",
-        attack: "Save: DEX DC 14",
-        damage: "Adv. to Hit",
+        effect: "Outline targets in light, granting advantage to hit them.",
+        rolls: "DEX save vs DC 14",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base 20-foot cube for advantage marking." },
+            { level: 5, summary: "Maintain the glow through key turns in combat." },
+            { level: 9, summary: "Sustain focus on priority targets." }
+        ],
+        concentration: true,
         desc: "Each object in a 20-foot cube within range is outlined in blue, green, or violet light (your choice). Any creature in the area when the spell is cast is also outlined if it fails a Dexterity saving throw. For the duration, objects and affected creatures shed dim light in a 10-foot radius.",
         incantation: "Lumen Febris",
         pronunciation: "LOO-men FEH-bris"
@@ -108,8 +164,15 @@ export const spells: Spell[] = [
         range: "Self",
         duration: "1 hour",
         components: "V, S",
-        attack: "Utility",
-        damage: "Change Look",
+        effect: "Alter your appearance with a visual illusion.",
+        rolls: "None",
+        damage: "—",
+        damageType: "Utility",
+        decisionTree: [
+            { level: 1, summary: "Base disguise for infiltration or escape." },
+            { level: 5, summary: "Blend into larger crowds without disruption." },
+            { level: 9, summary: "Maintain disguise through longer scenes." }
+        ],
         desc: "You make yourself—including your clothing, armor, weapons, and other belongings on your person—look different until the spell ends or until you use your action to dismiss it. You can seem 1 foot shorter or taller and can appear thin, fat, or in between.",
         incantation: "Facies Mutatio",
         pronunciation: "FAH-see-ehs moo-TAH-tee-oh"
@@ -123,8 +186,15 @@ export const spells: Spell[] = [
         range: "Self",
         duration: "1 round",
         components: "S",
-        attack: "Reaction",
+        effect: "Gain resistance to elemental damage and empower a strike.",
+        rolls: "Triggered reaction",
         damage: "+1d6",
+        damageType: "Acid/Cold/Fire/Lightning/Thunder",
+        decisionTree: [
+            { level: 1, summary: "Base: resistance + 1d6 bonus damage." },
+            { level: 5, summary: "Use to turn heavy hits into counterattacks." },
+            { level: 9, summary: "Conserve reactions for big elemental bursts." }
+        ],
         desc: "You have resistance to the triggering damage type (acid, cold, fire, lightning, or thunder) until the start of your next turn. Also, the first time you hit with a melee attack on your next turn, the target takes an extra 1d6 damage of the triggering type.",
         incantation: "Elementum Scutum",
         pronunciation: "eh-leh-MEN-toom SKOO-toom"
@@ -139,8 +209,16 @@ export const spells: Spell[] = [
         range: "60 ft",
         duration: "1 min (Conc.)",
         components: "V, S, M",
-        attack: "Save: INT DC 14",
-        damage: "1d6 Psychic/round",
+        effect: "Project an illusion that deals psychic damage each round.",
+        rolls: "INT save vs DC 14",
+        damage: "1d6 per round",
+        damageType: "Psychic",
+        decisionTree: [
+            { level: 3, summary: "Base illusion and 1d6 psychic damage per round." },
+            { level: 5, summary: "Sustain damage while repositioning or hiding." },
+            { level: 9, summary: "Use to lock down priority threats longer." }
+        ],
+        concentration: true,
         desc: "You craft an illusion in a creature's mind. On a failed INT save, you create a phantasmal object (max 10-foot cube). The target takes 1d6 psychic damage each round while within 5 feet of the illusion.",
         incantation: "Mentis Imago",
         pronunciation: "MEN-tis ih-MAH-go"
@@ -153,8 +231,16 @@ export const spells: Spell[] = [
         range: "30 ft",
         duration: "8 hours (Conc.)",
         components: "V, M",
-        attack: "Save: WIS DC 14",
-        damage: "Influence",
+        effect: "Magically compel a creature to follow a reasonable course of action.",
+        rolls: "WIS save vs DC 14",
+        damage: "—",
+        damageType: "Charm",
+        decisionTree: [
+            { level: 3, summary: "Base: 8 hours of compelled action." },
+            { level: 7, summary: "Use for extended tactical repositioning." },
+            { level: 9, summary: "Pair with social scenes for long-term control." }
+        ],
+        concentration: true,
         desc: "You suggest a course of activity (limited to a sentence or two) and magically influence a creature you can see within range that can hear and understand you. Creatures that can't be charmed are immune. The suggestion must be worded in such a manner as to make the course of action sound reasonable.",
         incantation: "Vox Imperium",
         pronunciation: "voks im-PEH-ree-oom"
@@ -167,8 +253,15 @@ export const spells: Spell[] = [
         range: "Self",
         duration: "1 minute",
         components: "V, S",
-        attack: "Utility",
-        damage: "3 Duplicates",
+        effect: "Create duplicates that force attackers to miss you.",
+        rolls: "d20 to redirect attacks",
+        damage: "—",
+        damageType: "Defense",
+        decisionTree: [
+            { level: 3, summary: "Base: 3 duplicates." },
+            { level: 5, summary: "Maintain defensive screen while repositioning." },
+            { level: 9, summary: "Combine with cover for layered defense." }
+        ],
         desc: "Three illusory duplicates of yourself appear in your space. Until the spell ends, the duplicates move with you and mimic your actions, shifting position so it's impossible to track which image is real. Each time a creature targets you with an attack, roll a d20 to determine whether it targets you or one of the duplicates.",
         incantation: "Speculum Triplex",
         pronunciation: "SPEH-kyoo-loom TREE-plex"
@@ -181,8 +274,15 @@ export const spells: Spell[] = [
         range: "10 ft",
         duration: "Instantaneous",
         components: "V, S, M",
-        attack: "Create Undead",
-        damage: "Raise Undead",
+        effect: "Raise skeletal or zombie servants and control them.",
+        rolls: "None",
+        damage: "Varies",
+        damageType: "Summon",
+        decisionTree: [
+            { level: 5, summary: "Base: animate/control up to 4 undead." },
+            { level: 7, summary: "Upcast: control 2 additional undead." },
+            { level: 9, summary: "Upcast: control 4 additional undead." }
+        ],
         desc: "Create an undead servant (Skeleton from bones, Zombie from corpse). You can control up to 4 creatures at once. The creature remains under your control for 24 hours. Reassert control by casting this spell again.",
         incantation: "Surgite Mortui",
         pronunciation: "sur-GEE-teh MOR-too-ee"
@@ -195,8 +295,16 @@ export const spells: Spell[] = [
         range: "90 ft",
         duration: "1 hr (Conc.)",
         components: "V, S, M (300gp)",
-        attack: "Spirit",
+        effect: "Call forth a ghostly, putrid, or skeletal spirit.",
+        rolls: "Use summoned stat block",
         damage: "Varies",
+        damageType: "Necrotic",
+        decisionTree: [
+            { level: 5, summary: "Choose Ghostly, Putrid, or Skeletal spirit." },
+            { level: 7, summary: "Upcast: +1 AC, +10 HP, +1 damage per attack." },
+            { level: 9, summary: "Upcast: +2 AC, +20 HP, +2 damage per attack." }
+        ],
+        concentration: true,
         desc: "Call forth an undead spirit (Ghostly, Putrid, or Skeletal). The spirit obeys your verbal commands. GHOSTLY: Fly 40ft, Frightening Presence. PUTRID: Poison Aura. SKELETAL: Ranged attacks 150ft.",
         incantation: "Spiritus Invoco",
         pronunciation: "SPEE-ree-toos in-VOH-koh"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,11 +17,20 @@ export interface Spell {
     range: string;
     duration: string;
     components: string;
-    attack: string;
+    effect: string;
+    rolls: string;
     damage: string;
+    damageType: string;
+    decisionTree: SpellDecision[];
+    concentration?: boolean;
     desc: string;
     incantation?: string;
     pronunciation?: string;
+}
+
+export interface SpellDecision {
+    level: number;
+    summary: string;
 }
 
 export interface MinionStats {
@@ -75,12 +84,6 @@ export interface CharacterData {
     concentration: string | null; // Currently concentrating on this spell
     attunement: string[]; // Max 3 attuned magic items
     inventory: string[]; // General inventory items
-    transformed: { // Wild Shape / Polymorph state
-        active: boolean;
-        creatureName: string;
-        hp: { current: number; max: number };
-        ac: number;
-    } | null;
 }
 
 export interface Session {

--- a/src/utils/spellRules.ts
+++ b/src/utils/spellRules.ts
@@ -1,0 +1,4 @@
+export function getRequiredLevelForSpell(spellLevel: number): number {
+    if (spellLevel <= 0) return 1;
+    return Math.max(1, spellLevel * 2 - 1);
+}


### PR DESCRIPTION
### Motivation
- Make spells, summons, and skills more dynamic and wizard-focused by adding structured metadata and per-level decision logic. 
- Surface what a spell does, what rolls it requires, damage and damage type, and allow quick concentration selection for combat. 
- Represent skills relationally so they clearly link to their governing ability and show derived modifiers. 
- Remove Wild Shape/wild hunt integration for a wizard-centric UX.

### Description
- Expanded the `Spell` model in `src/types/index.ts` to include `effect`, `rolls`, `damageType`, `decisionTree: SpellDecision[]`, and a `concentration` flag, and added the `SpellDecision` type. 
- Replaced free-form spell entries in `src/data/spells.ts` with enriched records and per-level `decisionTree` guidance for each spell. 
- Updated `src/components/views/SpellsView.tsx` to show availability by character `level`, a quick-reference grid (`What It Does`, `Rolls`, `Damage`, `Damage Type`), per-level decision tree UI, and a `Set Concentration` action wired to the app. 
- Added `src/utils/spellRules.ts` with `getRequiredLevelForSpell` to gate spell availability, updated `ConcentrationWidget` to accept suggested concentration spells, and regrouped skills by ability in `src/components/views/CharacterView.tsx`; also removed Wild Shape hooks from the combat area and initial state.

### Testing
- Launched the dev server with `vite` and verified the app loads successfully. 
- Performed automated browser smoke checks using Playwright to capture the home screen and spells list/modal to confirm UI changes rendered. 
- No unit tests were executed (`vitest` not run) during this rollout. 
- All changes compiled and the development server remained responsive during UI checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963730045bc8321894d539e215942c5)