### PR TITLE
Add Redux Toolkit store, character & combat slices, selectors, and listener middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,11 @@
         "@capacitor/android": "^8.0.0",
         "@capacitor/cli": "^8.0.0",
         "@capacitor/core": "^8.0.0",
+        "@reduxjs/toolkit": "^2.11.2",
         "lucide-react": "^0.555.0",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-redux": "^9.2.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -155,7 +157,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1762,7 +1763,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.0.0.tgz",
       "integrity": "sha512-250HTVd/W/KdMygoqaedisvNbHbpbQTN2Hy/8ZYGm1nAqE0Fx7sGss4l0nDg33STxEdDhtVRoL2fIaaiukKseA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1855,7 +1855,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1899,7 +1898,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2874,6 +2872,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.47",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.47.tgz",
@@ -3264,7 +3288,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -3656,7 +3685,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3757,9 +3787,8 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3770,7 +3799,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3793,6 +3821,12 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3841,7 +3875,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -4200,7 +4233,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -4246,7 +4278,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4615,7 +4646,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4901,7 +4931,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -5120,7 +5150,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5436,7 +5467,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6296,6 +6326,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.3.tgz",
+      "integrity": "sha512-6jQTc5z0KJFtr1UgFpIL3N9XSC3saRaI9PwWtzM2pSqkNGtiNkYY2OSwkOGDK2XcTRcLb1pi/aNkKZz0nxVH4Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -7433,6 +7473,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7923,7 +7964,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7969,6 +8009,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7984,6 +8025,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7994,6 +8036,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8048,7 +8091,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8058,7 +8100,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8071,7 +8112,31 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -8109,6 +8174,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8223,6 +8303,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -8311,7 +8397,6 @@
       "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9398,7 +9483,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9583,6 +9667,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9595,7 +9688,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9702,7 +9794,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",
@@ -10105,7 +10196,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10173,7 +10263,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10522,7 +10611,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "@capacitor/android": "^8.0.0",
     "@capacitor/cli": "^8.0.0",
     "@capacitor/core": "^8.0.0",
+    "@reduxjs/toolkit": "^2.11.2",
     "lucide-react": "^0.555.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-redux": "^9.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,14 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import './index.css';
+import App from './App.tsx';
+import { store } from './store/store';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>,
-)
+);

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector = <Selected>(
+  selector: (state: RootState) => Selected,
+) => useSelector(selector);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export { store } from './store';
+export type { RootState, AppDispatch } from './store';
+export { useAppDispatch, useAppSelector } from './hooks';

--- a/src/store/middleware/combatListeners.ts
+++ b/src/store/middleware/combatListeners.ts
@@ -1,0 +1,33 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit';
+import {
+  recordDamage,
+  setPendingConcentrationCheck,
+} from '../slices/combatSlice';
+
+export const combatListenerMiddleware = createListenerMiddleware();
+
+combatListenerMiddleware.startListening({
+  actionCreator: recordDamage,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+    const concentration = state.combat.concentration;
+
+    if (!concentration) {
+      return;
+    }
+
+    if (action.payload.targetId !== concentration.casterId) {
+      return;
+    }
+
+    const dc = Math.max(10, Math.floor(action.payload.amount / 2));
+
+    listenerApi.dispatch(
+      setPendingConcentrationCheck({
+        casterId: concentration.casterId,
+        spellVariantId: concentration.spellVariantId,
+        dc,
+      }),
+    );
+  },
+});

--- a/src/store/selectors/characterSelectors.ts
+++ b/src/store/selectors/characterSelectors.ts
@@ -1,0 +1,90 @@
+import { createSelector } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+import type { AbilityType } from '../slices/characterSlice';
+
+const abilitySkillMap: Record<AbilityType, string[]> = {
+  STR: ['athletics'],
+  DEX: ['acrobatics', 'sleight-of-hand', 'stealth'],
+  CON: [],
+  INT: ['arcana', 'history', 'investigation', 'nature', 'religion'],
+  WIS: ['animal-handling', 'insight', 'medicine', 'perception', 'survival'],
+  CHA: ['deception', 'intimidation', 'performance', 'persuasion'],
+};
+
+const formatSkillName = (skillId: string) =>
+  skillId
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
+export const selectAbilities = (state: RootState) => state.character.abilities;
+export const selectSkillProficiencies = (state: RootState) =>
+  state.character.skillProficiencies;
+export const selectLevel = (state: RootState) => state.character.level;
+
+export const selectProficiencyBonus = createSelector(
+  [selectLevel],
+  (level) => 2 + Math.floor((level - 1) / 4),
+);
+
+export const selectAbilityModifiers = createSelector(
+  [selectAbilities],
+  (abilities) =>
+    (Object.entries(abilities) as [AbilityType, number][]).reduce(
+      (acc, [ability, score]) => {
+        acc[ability] = Math.floor((score - 10) / 2);
+        return acc;
+      },
+      {} as Record<AbilityType, number>,
+    ),
+);
+
+export const selectAbilitySkillTree = createSelector(
+  [selectAbilities, selectSkillProficiencies, selectProficiencyBonus],
+  (abilities, proficiencies, profBonus) =>
+    (Object.entries(abilitySkillMap) as [AbilityType, string[]][]).map(
+      ([ability, skillIds]) => {
+        const score = abilities[ability];
+        const baseModifier = Math.floor((score - 10) / 2);
+        const skills = skillIds.map((skillId) => {
+          const proficiency = proficiencies[skillId] ?? 'none';
+          let totalModifier = baseModifier;
+
+          if (proficiency === 'proficient') {
+            totalModifier += profBonus;
+          }
+
+          if (proficiency === 'expertise') {
+            totalModifier += profBonus * 2;
+          }
+
+          return {
+            id: skillId,
+            name: formatSkillName(skillId),
+            proficiency,
+            totalModifier,
+            abilityModifier: baseModifier,
+            badge:
+              proficiency === 'expertise'
+                ? 'gold-crown'
+                : proficiency === 'proficient'
+                  ? 'silver-check'
+                  : 'none',
+          };
+        });
+
+        return {
+          ability,
+          abilityScore: score,
+          baseModifier,
+          skills,
+          ...(ability === 'WIS' && {
+            passivePerception:
+              10 +
+              (skills.find((skill) => skill.id === 'perception')?.totalModifier ??
+                baseModifier),
+          }),
+        };
+      },
+    ),
+);

--- a/src/store/slices/characterSlice.ts
+++ b/src/store/slices/characterSlice.ts
@@ -1,0 +1,85 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type AbilityType = 'STR' | 'DEX' | 'CON' | 'INT' | 'WIS' | 'CHA';
+export type SkillProficiency = 'none' | 'proficient' | 'expertise';
+
+export interface CharacterState {
+  abilities: Record<AbilityType, number>;
+  skillProficiencies: Record<string, SkillProficiency>;
+  savingThrowProficiencies: Partial<Record<AbilityType, boolean>>;
+  level: number;
+  class: string;
+}
+
+const clampLevel = (level: number) => Math.min(20, Math.max(1, level));
+
+const initialState: CharacterState = {
+  abilities: {
+    STR: 8,
+    DEX: 14,
+    CON: 14,
+    INT: 17,
+    WIS: 15,
+    CHA: 10,
+  },
+  skillProficiencies: {
+    arcana: 'expertise',
+    history: 'proficient',
+    insight: 'proficient',
+    investigation: 'proficient',
+  },
+  savingThrowProficiencies: {
+    INT: true,
+    WIS: true,
+  },
+  level: 5,
+  class: 'Wizard',
+};
+
+const characterSlice = createSlice({
+  name: 'character',
+  initialState,
+  reducers: {
+    setAbilityScore(
+      state,
+      action: PayloadAction<{ ability: AbilityType; score: number }>,
+    ) {
+      const { ability, score } = action.payload;
+      state.abilities[ability] = score;
+    },
+    setSkillProficiency(
+      state,
+      action: PayloadAction<{ skillId: string; proficiency: SkillProficiency }>,
+    ) {
+      const { skillId, proficiency } = action.payload;
+      state.skillProficiencies[skillId] = proficiency;
+    },
+    toggleSavingThrowProficiency(
+      state,
+      action: PayloadAction<{ ability: AbilityType; proficient: boolean }>,
+    ) {
+      const { ability, proficient } = action.payload;
+      state.savingThrowProficiencies[ability] = proficient;
+    },
+    setLevel(state, action: PayloadAction<number>) {
+      state.level = clampLevel(action.payload);
+    },
+    setClass(state, action: PayloadAction<string>) {
+      state.class = action.payload;
+    },
+    hydrateCharacter(_state, action: PayloadAction<CharacterState>) {
+      return action.payload;
+    },
+  },
+});
+
+export const {
+  setAbilityScore,
+  setSkillProficiency,
+  toggleSavingThrowProficiency,
+  setLevel,
+  setClass,
+  hydrateCharacter,
+} = characterSlice.actions;
+
+export default characterSlice.reducer;

--- a/src/store/slices/combatSlice.ts
+++ b/src/store/slices/combatSlice.ts
@@ -1,0 +1,140 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface Combatant {
+  id: string;
+  name: string;
+  initiative: number;
+}
+
+export interface ConcentrationState {
+  casterId: string;
+  spellVariantId: string;
+  startTime: number;
+  source?: string;
+}
+
+export interface DamageEvent {
+  targetId: string;
+  amount: number;
+  timestamp: number;
+}
+
+export interface PendingConcentrationCheck {
+  casterId: string;
+  spellVariantId: string;
+  dc: number;
+}
+
+export interface CombatState {
+  turnOrder: Combatant[];
+  currentTurn: number;
+  round: number;
+  concentration: ConcentrationState | null;
+  conditions: Record<string, string[]>;
+  minions: string[];
+  damageEvents: DamageEvent[];
+  pendingConcentrationCheck: PendingConcentrationCheck | null;
+}
+
+const initialState: CombatState = {
+  turnOrder: [],
+  currentTurn: 0,
+  round: 1,
+  concentration: null,
+  conditions: {},
+  minions: [],
+  damageEvents: [],
+  pendingConcentrationCheck: null,
+};
+
+const combatSlice = createSlice({
+  name: 'combat',
+  initialState,
+  reducers: {
+    setTurnOrder(state, action: PayloadAction<Combatant[]>) {
+      state.turnOrder = action.payload;
+    },
+    advanceTurn(state) {
+      if (state.turnOrder.length === 0) {
+        return;
+      }
+      const nextTurn = (state.currentTurn + 1) % state.turnOrder.length;
+      state.currentTurn = nextTurn;
+      if (nextTurn === 0) {
+        state.round += 1;
+      }
+    },
+    setActiveConcentration(state, action: PayloadAction<ConcentrationState>) {
+      state.concentration = action.payload;
+      state.pendingConcentrationCheck = null;
+    },
+    clearConcentration(state) {
+      state.concentration = null;
+      state.pendingConcentrationCheck = null;
+    },
+    addCondition(
+      state,
+      action: PayloadAction<{ combatantId: string; condition: string }>,
+    ) {
+      const { combatantId, condition } = action.payload;
+      const current = state.conditions[combatantId] ?? [];
+      state.conditions[combatantId] = [...current, condition];
+    },
+    removeCondition(
+      state,
+      action: PayloadAction<{ combatantId: string; condition: string }>,
+    ) {
+      const { combatantId, condition } = action.payload;
+      const current = state.conditions[combatantId] ?? [];
+      state.conditions[combatantId] = current.filter((entry) => entry !== condition);
+    },
+    addMinion(state, action: PayloadAction<string>) {
+      state.minions = [...state.minions, action.payload];
+    },
+    removeMinion(state, action: PayloadAction<string>) {
+      state.minions = state.minions.filter((id) => id !== action.payload);
+    },
+    recordDamage(state, action: PayloadAction<{ targetId: string; amount: number }>) {
+      state.damageEvents = [
+        ...state.damageEvents,
+        { ...action.payload, timestamp: Date.now() },
+      ];
+    },
+    setPendingConcentrationCheck(
+      state,
+      action: PayloadAction<PendingConcentrationCheck>,
+    ) {
+      state.pendingConcentrationCheck = action.payload;
+    },
+    clearPendingConcentrationCheck(state) {
+      state.pendingConcentrationCheck = null;
+    },
+    resetCombat(state) {
+      state.turnOrder = [];
+      state.currentTurn = 0;
+      state.round = 1;
+      state.concentration = null;
+      state.conditions = {};
+      state.minions = [];
+      state.damageEvents = [];
+      state.pendingConcentrationCheck = null;
+    },
+  },
+});
+
+export const {
+  setTurnOrder,
+  advanceTurn,
+  setActiveConcentration,
+  clearConcentration,
+  addCondition,
+  removeCondition,
+  addMinion,
+  removeMinion,
+  recordDamage,
+  setPendingConcentrationCheck,
+  clearPendingConcentrationCheck,
+  resetCombat,
+} = combatSlice.actions;
+
+export default combatSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,16 @@
+import { configureStore } from '@reduxjs/toolkit';
+import characterReducer from './slices/characterSlice';
+import combatReducer from './slices/combatSlice';
+import { combatListenerMiddleware } from './middleware/combatListeners';
+
+export const store = configureStore({
+  reducer: {
+    character: characterReducer,
+    combat: combatReducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().prepend(combatListenerMiddleware.middleware),
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
### Motivation

- Introduce a Single Source of Truth (SSOT) for character and combat data to avoid storing derived values and to centralize state changes.
- Provide a selector layer to derive view models (ability modifiers, skill tree, proficiency bonus) from raw character data.
- Add combat-focused state (initiative, concentration, conditions, damage events) and a middleware to surface concentration checks when damage is recorded.
- Wire the React app into Redux so UI components can consume centralized state and derived selectors.

### Description

- Add Redux Toolkit and React-Redux dependencies and wire the app to the store by wrapping `App` with `Provider` in `src/main.tsx` and exporting `store` from `src/store/store.ts`.
- Introduce `characterSlice` with raw ability scores, skill proficiencies, saving throw proficiencies, and level management in `src/store/slices/characterSlice.ts`.
- Introduce `combatSlice` to track initiative, rounds, concentration state, conditions, minions, damage events, and pending concentration checks in `src/store/slices/combatSlice.ts`.
- Add selector layer `src/store/selectors/characterSelectors.ts` for derived data (`selectProficiencyBonus`, `selectAbilityModifiers`, `selectAbilitySkillTree`) and create listener middleware `src/store/middleware/combatListeners.ts` to dispatch concentration checks when `recordDamage` occurs, plus typed hooks in `src/store/hooks.ts` and re-exports in `src/store/index.ts`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637c63082083218cd4c042ae83d23d)