### PR TITLE
Add floating Combat HUD widget

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { InitiativeWidget } from './components/widgets/InitiativeWidget';
 import { ProficiencyWidget } from './components/widgets/ProficiencyWidget';
 import { SavingThrowsWidget } from './components/widgets/SavingThrowsWidget';
 import { CharacterEditor } from './components/widgets/CharacterEditor';
+import { CombatHUD } from './components/widgets/CombatHUD';
 import SpellsView from './components/views/SpellsView';
 import { CombatView } from './components/views/CombatView';
 import { CombatOverlay } from './components/views/CombatOverlay';
@@ -464,6 +465,16 @@ function App() {
 
       {/* Combat Overlay System */}
       <CombatOverlay />
+
+      {activeTab !== 'home' && activeTab !== 'settings' && (
+        <CombatHUD
+          baseAC={data.baseAC}
+          dexMod={data.abilityMods.dex}
+          mageArmour={data.mageArmour}
+          hasShield={data.shield}
+          concentrationSpell={data.concentration}
+        />
+      )}
 
       {/* Toast */}
       {

--- a/src/components/widgets/CombatHUD.tsx
+++ b/src/components/widgets/CombatHUD.tsx
@@ -1,0 +1,68 @@
+import { useAppSelector } from '../../store/hooks';
+import { selectSpellAttackBonus, selectSpellSaveDC } from '../../store/slices/characterSlice';
+
+interface CombatHUDProps {
+    baseAC: number;
+    dexMod: number;
+    mageArmour: boolean;
+    hasShield: boolean;
+    concentrationSpell?: string | null;
+}
+
+export function CombatHUD({
+    baseAC,
+    dexMod,
+    mageArmour,
+    hasShield,
+    concentrationSpell,
+}: CombatHUDProps) {
+    const spellSaveDC = useAppSelector(selectSpellSaveDC);
+    const spellAttackBonus = useAppSelector(selectSpellAttackBonus);
+    const activeConcentration = useAppSelector(state => state.combat.activeConcentration);
+
+    const mageArmorAC = 13 + dexMod;
+    const effectiveBaseAC = mageArmour ? mageArmorAC : baseAC;
+    const currentAC = effectiveBaseAC + (hasShield ? 5 : 0);
+
+    const concentrationName = activeConcentration?.spellName ?? concentrationSpell;
+    const attackBonusLabel = spellAttackBonus >= 0 ? `+${spellAttackBonus}` : `${spellAttackBonus}`;
+    const concentrationActive = Boolean(concentrationName);
+
+    return (
+        <div
+            className={`fixed bottom-2 right-2 z-40 w-44 rounded-lg bg-black/70 backdrop-blur-md p-3 text-parchment shadow-lg sm:bottom-4 sm:right-4 sm:w-52 ${
+                concentrationActive
+                    ? 'glow-border border border-purple-400/40 shadow-[0_0_14px_rgba(168,85,247,0.35)]'
+                    : 'border border-white/10'
+            }`}
+        >
+            <div className="flex items-center justify-between border-b border-white/10 pb-2">
+                <span className="font-display text-xs uppercase tracking-[0.2em] text-parchment-light">⚔️ Combat</span>
+                {concentrationActive && (
+                    <span className="text-[10px] uppercase tracking-widest text-purple-300">Concentrating</span>
+                )}
+            </div>
+
+            <div className="mt-2 space-y-2 text-sm">
+                <div className="flex items-center justify-between">
+                    <span className="text-muted">DC</span>
+                    <span className="font-display text-parchment-light">{spellSaveDC}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                    <span className="text-muted">ATK</span>
+                    <span className="font-display text-parchment-light">{attackBonusLabel}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                    <span className="text-muted">AC</span>
+                    <span className="font-display text-parchment-light">{currentAC}</span>
+                </div>
+                {concentrationName && (
+                    <div className="flex items-center gap-2 text-xs text-parchment-light">
+                        <span>🔮</span>
+                        <span className="truncate">{concentrationName}</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
### Motivation
- Provide a compact, always-visible combat overlay that surfaces essential combat stats during play (Spell Save DC, Spell Attack Bonus, AC, Concentration).
- Ensure the HUD matches the project's parchment/fantasy theme and remains visible outside the tab content during combat.
- Calculate AC from character state including `mageArmour`, DEX modifier and `shield` status to reflect current defenses.
- Give clear visual feedback when concentration is active via a subtle glow.

### Description
- Added a new component `src/components/widgets/CombatHUD.tsx` that reads `selectSpellSaveDC` and `selectSpellAttackBonus` from the character slice and `state.combat.activeConcentration` from the combat slice, and computes AC using `mageArmour`, DEX and `shield` props.
- The HUD uses existing Tailwind/CSS classes (e.g. `bg-black/70`, `backdrop-blur-md`, `text-parchment`, `glow-border`) and is sized/positioned as a fixed panel in the lower-right corner (`fixed bottom-2 right-2 sm:bottom-4 sm:right-4 sm:w-52`).
- Integrated the HUD into `src/App.tsx` (import and render) so it sits outside the tab system and is shown when `activeTab` is not `home` or `settings`.
- The component shows `DC`, `ATK`, `AC`, and the current concentration spell name when active, and adds a glow-border when concentrating.

### Testing
- Started the dev server with `npm run dev` (Vite) to smoke-check the app startup and it reported ready (success).
- Ran a Playwright smoke script to load the UI, navigate to the combat area and capture a screenshot of the HUD (artifact `artifacts/combat-hud.png`) which completed successfully.
- No unit tests or test-suite runs were executed as part of this change.
- The HUD was visually inspected in the screenshot for placement, styling, and shown values (manual verification via automated screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658ee3d5488321a106e09beae3391e)