### PR TITLE
Wrap app in ErrorBoundary and fix type-only imports for Redux types

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import './index.css'
 import App from './App.tsx'
 import { store } from './store'
@@ -8,7 +9,9 @@ import { store } from './store'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Provider store={store}>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </Provider>
   </StrictMode>,
 )

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,4 +1,5 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
 import type { RootState, AppDispatch } from './index';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`

--- a/src/store/slices/characterSlice.ts
+++ b/src/store/slices/characterSlice.ts
@@ -8,7 +8,8 @@
  * Persistence is handled by the persistenceMiddleware which saves
  * to sessionStorage on every action.
  */
-import { createSlice, PayloadAction, createSelector } from '@reduxjs/toolkit';
+import { createSlice, createSelector } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import type { CharacterData, AbilityKey, InventoryItem, Minion } from '../../types';
 import { initialCharacterData } from '../../data/initialState';
 import { getActiveSession } from '../../utils/sessionStorage';

--- a/src/store/slices/spellbookSlice.ts
+++ b/src/store/slices/spellbookSlice.ts
@@ -1,4 +1,5 @@
-import { createEntityAdapter, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createEntityAdapter, createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
 import { z } from 'zod';
 import { SpellSchema } from '../../schemas/spellSchema';
 


### PR DESCRIPTION
### Motivation

- Fix TypeScript build errors complaining that Redux types must be imported as type-only symbols.  
- Ensure global error handling by wrapping the entire app root with the existing `ErrorBoundary` so crashes in any tab don't bring down the whole PWA.  
- Address immediate blockers from `tsc` output so the project is closer to a successful `npm run build`.  

### Description

- Converted Redux type imports to type-only imports in `src/store/hooks.ts`, `src/store/slices/characterSlice.ts`, and `src/store/slices/spellbookSlice.ts` by using `import type { ... }` where appropriate.  
- Wrapped the application root with `ErrorBoundary` in `src/main.tsx` so `App` is rendered inside `<ErrorBoundary>`.  
- Edited `src/store/hooks.ts` to import runtime hooks normally and `TypedUseSelectorHook` as a type-only import to satisfy verbatim module rules.  

### Testing

- No automated tests were executed for these changes.  
- TypeScript compilation (`npm run build`) was not run as part of this PR.  
- Manual linting or runtime verification was not performed in CI as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965cec22b3883218cf117632886c78b)